### PR TITLE
Fix invalid key check

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-var invalidKey = regexp.MustCompile("^(commit|tree|parent|author|committer|encoding|[^a-zA-Z0-9])$").MatchString
+var invalidKey = regexp.MustCompile(`^(commit|tree|parent|author|committer|encoding)\b|[^a-zA-Z0-9]`).MatchString
 var validPrefix = regexp.MustCompile("^[0-9a-f]{1,40}$").MatchString
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,8 @@ func TestInvalidKey(t *testing.T) {
 		{"author", true},
 		{"committer", true},
 		{"encoding", true},
+		{"commit ", true},
+		{"non-alphanumeric", true},
 		{"x", false},
 		{"f00", false},
 	} {


### PR DESCRIPTION
The regex lists a couple of reserved headers, and tries to assert that
the key is fully alphanumeric. However, there are two issues:

- The check was anchored, so 'tree ' would not be considered invalid
  (while still breaking the git commit header)
- The check for invalid characters currently only checks for a single
  character. Adding a + doesn't fix this, because even then it would
  only match keys that are fully non-alphanumeric.

Sanity check: https://regex101.com/r/bBq8ZW/1